### PR TITLE
runinterval back to the default 30m

### DIFF
--- a/setup_puppet-agent.sh
+++ b/setup_puppet-agent.sh
@@ -8,8 +8,8 @@ ELMAJ_VER="7"
 PUP_VER="6"
 PUP_URL="https://yum.puppetlabs.com/puppet${PUP_VER}/puppet${PUP_VER}-release-el-${ELMAJ_VER}.noarch.rpm"
 PUP_ENV="development"
-PUP_RUNINTERVAL="7200" # 2h
-PUP_RUNTIMEOUT="900"  # 15m
+PUP_RUNINTERVAL="1800" # 30m
+PUP_RUNTIMEOUT="1200"  # 20m
 
 # General functions used in shell scripts
 prompt_confirm() {


### PR DESCRIPTION
After tuning the puppetserver the runtinterval can be decreased to the
default of 30m again.

# Closes issue(s)

Fixes #3

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [X] I have tested this code
- [X] I have updated the README.md (if available and necessary)

