### PR TITLE
remove set -e from setup-puppetmaster.sh

### DIFF
--- a/setup_puppetmaster.sh
+++ b/setup_puppetmaster.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 
 # General settings
 TENANT="ID-SYS"


### PR DESCRIPTION
After installing a new virtual box, the setup_puppetmaster.sh script breaks off when it is executed.

'set -e' Exit immediately if a command exits with a non-zero status.

The last change

"Install reuqired gem diff-lcs for show_diff"

ends with a non-zero status.

We decided not to change the query.

set -e is removed