### PR TITLE
Check for vboxfs mountpoint

### DIFF
--- a/refresh_modules.sh
+++ b/refresh_modules.sh
@@ -47,7 +47,7 @@ then
   exit 1
 fi
 
-if [ ! -f /etc/vagrant_box_build_time ]
+if [ ! -d /vagrant ]
 then
   fail "Not in a virtualbox machine. Refusing to work."
   exit 1


### PR DESCRIPTION
The script refresh_modules.sh now checks for the mountpoint `/vagrant`
to determine if inside a VM.

# Closes issue(s)

Fixes #11

# Changes include
- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [X] I have tested this code
- [X] I have updated the README.md (if available and necessary)

