### PR TITLE
Create local users and groups at VM boot time

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -125,6 +125,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |global|
     end
     config.vm.provision :hosts, :sync_hosts => true
     config.vm.provision "shell", inline: "/vagrant/setup_puppet-agent.sh slurmmaster_test infraserver local"
+    config.vm.provision "shell", inline: "/vagrant/create_local_users.sh"
   end
 
   #
@@ -196,6 +197,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |global|
       config.vm.provision :hosts, :sync_hosts => true
       config.vm.provision "shell", inline: "mkdir -p /scratch"
       config.vm.provision "shell", inline: "/vagrant/setup_puppet-agent.sh submit frontendserver local"
+      config.vm.provision "shell", inline: "/vagrant/create_local_users.sh"
     end
   end
 
@@ -231,6 +233,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |global|
       config.vm.provision :hosts, :sync_hosts => true
       config.vm.provision "shell", inline: "mkdir -p /scratch"
       config.vm.provision "shell", inline: "/vagrant/setup_puppet-agent.sh anode computenode local"
+      config.vm.provision "shell", inline: "/vagrant/create_local_users.sh"
     end
   end
 
@@ -249,6 +252,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |global|
       config.vm.provision :hosts, :sync_hosts => true
       config.vm.provision "shell", inline: "mkdir -p /scratch"
       config.vm.provision "shell", inline: "/vagrant/setup_puppet-agent.sh knode computenode local"
+      config.vm.provision "shell", inline: "/vagrant/create_local_users.sh"
     end
   end
 

--- a/create_local_users.sh
+++ b/create_local_users.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# The slurm and munge user and group are in LDAP
+# in production envrionment while we do not have
+# a working LDAP in Pocket-UBELIX (yet?).
+#
+# Therefore we create them explicitly at VM
+# creation time with this script
+export MUNGEUSER=469
+export SLURMUSER=468
+
+if ! getent group munge &>/dev/null
+then
+  groupadd -g $MUNGEUSER munge
+fi
+
+if ! getent passwd munge &>/dev/null
+then
+  useradd  -m -c "Runs Uid 'N' Gid Emporium" -d /var/lib/munge -u $MUNGEUSER -g munge  -s /sbin/nologin munge
+fi
+
+if ! getent group slurm &>/dev/null
+then
+  groupadd -g $SLURMUSER slurm
+fi
+
+if ! getent passwd slurm &>/dev/null
+then
+  useradd  -m -c "SLURM User" -d /var/lib/slurm -u $SLURMUSER -g slurm  -s /sbin/nologin slurm
+fi


### PR DESCRIPTION
Every time the machine starts the create_loca_users.sh script is called
and the user and group for slurm and munge are created if not already
available.
This is only need on lrms, submits and compute nodes

# Closes issue(s)

Fixes #19

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [X] I have tested this code
- [X] I have updated the README.md (if available and necessary)

